### PR TITLE
Removing use of calculateFunctionHash function

### DIFF
--- a/lib/resource-initializer.ts
+++ b/lib/resource-initializer.ts
@@ -3,9 +3,7 @@
 
 import * as ec2 from '@aws-cdk/aws-ec2'
 import * as lambda from '@aws-cdk/aws-lambda'
-import { Construct, Duration, Stack, Tags } from '@aws-cdk/core'
-import { createHash } from 'crypto'
-import { calculateFunctionHash } from '@aws-cdk/aws-lambda/lib/function-hash'
+import { Construct, Duration, Stack } from '@aws-cdk/core'
 import { AwsCustomResource, AwsCustomResourcePolicy, AwsSdkCall, PhysicalResourceId } from '@aws-cdk/custom-resources'
 import { RetentionDays } from '@aws-cdk/aws-logs'
 import { PolicyStatement, Role, ServicePrincipal } from '@aws-cdk/aws-iam'
@@ -55,10 +53,6 @@ export class CdkResourceInitializer extends Construct {
       }
     })
 
-    const physicalResIdHash = createHash('md5')
-      .update(calculateFunctionHash(fn) + payload)
-      .digest('hex')
-
     const sdkCall: AwsSdkCall = {
       service: 'Lambda',
       action: 'invoke',
@@ -66,7 +60,7 @@ export class CdkResourceInitializer extends Construct {
         FunctionName: fn.functionName,
         Payload: payload
       },
-      physicalResourceId: PhysicalResourceId.of(`${id}-AwsSdkCall-${physicalResIdHash}`)
+      physicalResourceId: PhysicalResourceId.of(`${id}-AwsSdkCall-${fn.currentVersion.version}`)
     }
     
     // IMPORTANT: the AwsCustomResource construct deploys a singleton AWS Lambda function that is re-used across the same CDK Stack,


### PR DESCRIPTION
*Description of changes:*
- We drop the usage of the internal `calculateFunctionHash` function to use the `fn.currentVersion.version` public attribute instead.
